### PR TITLE
[APPSRE-2596] Fix "Request Entity Too Large"

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ existing model or by creating new ones. Models are placed
 
 ## DB Upgrade
 
-Create the upgrade route executing the command:
+Create the upgrade routine executing the command:
 
 ```
 $ FLASK_APP=dashdotdb flask db migrate

--- a/dashdotdb/__init__.py
+++ b/dashdotdb/__init__.py
@@ -9,11 +9,18 @@ from dashdotdb.models.base import db
 from dashdotdb.models import imagemanifestvuln  # type: ignore  # noqa: F401
 
 
-DATABASE_HOST = os.environ['DATABASE_HOST']
-DATABASE_PORT = os.environ['DATABASE_PORT']
-DATABASE_USERNAME = os.environ['DATABASE_USERNAME']
-DATABASE_PASSWORD = os.environ['DATABASE_PASSWORD']
-DATABASE_NAME = os.environ['DATABASE_NAME']
+DATABASE_URL = os.environ.get('DASHDOTDB_DATABASE_URL')
+if DATABASE_URL is None:
+    DATABASE_HOST = os.environ['DATABASE_HOST']
+    DATABASE_PORT = os.environ['DATABASE_PORT']
+    DATABASE_USERNAME = os.environ['DATABASE_USERNAME']
+    DATABASE_PASSWORD = os.environ['DATABASE_PASSWORD']
+    DATABASE_NAME = os.environ['DATABASE_NAME']
+    DATABASE_URL = (f'postgresql://{DATABASE_USERNAME}:'
+                    f'{DATABASE_PASSWORD}@'
+                    f'{DATABASE_HOST}:'
+                    f'{DATABASE_PORT}/'
+                    f'{DATABASE_NAME}')
 
 
 class DashDotDb(App):
@@ -21,12 +28,7 @@ class DashDotDb(App):
         # pylint: disable=redefined-outer-name
         app = Flask(self.import_name, **self.server_args)
 
-        db_url = (f'postgresql://{DATABASE_USERNAME}:'
-                  f'{DATABASE_PASSWORD}@'
-                  f'{DATABASE_HOST}:'
-                  f'{DATABASE_PORT}/'
-                  f'{DATABASE_NAME}')
-        app.config['SQLALCHEMY_DATABASE_URI'] = db_url
+        app.config['SQLALCHEMY_DATABASE_URI'] = DATABASE_URL
         app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
         db.init_app(app)
         # pylint: disable=unused-variable

--- a/dashdotdb/schemas/swagger.yaml
+++ b/dashdotdb/schemas/swagger.yaml
@@ -94,34 +94,44 @@ components:
     ItemsImageManifestVuln:
         type: object
         required:
-          - items
+        - kind
+        - spec
         properties:
-          items:
-            type: array
-            items:
-              type: object
-              required:
-              - kind
-              - spec
-              properties:
-                kind:
-                  type: string
-                  enum:
-                    - ImageManifestVuln
-                # https://github.com/quay/container-security-operator/blob/c88d3a2/deploy/imagemanifestvuln.crd.yaml
-                spec:
+          kind:
+            type: string
+            enum:
+              - ImageManifestVuln
+          # https://github.com/quay/container-security-operator/blob/c88d3a2/deploy/imagemanifestvuln.crd.yaml
+          spec:
+            type: object
+            properties:
+              image:
+                type: string
+                minLength: 1
+              manifest:
+                type: string
+                minLength: 1
+              namespaceName:
+                type: string
+                minLength: 1
+              features:
+                type: array
+                items:
                   type: object
                   properties:
-                    image:
+                    name:
                       type: string
                       minLength: 1
-                    manifest:
+                    versionformat:
                       type: string
                       minLength: 1
                     namespaceName:
                       type: string
                       minLength: 1
-                    features:
+                    version:
+                      type: string
+                      minLength: 1
+                    vulnerabilities:
                       type: array
                       items:
                         type: object
@@ -129,77 +139,60 @@ components:
                           name:
                             type: string
                             minLength: 1
-                          versionformat:
-                            type: string
-                            minLength: 1
                           namespaceName:
                             type: string
                             minLength: 1
-                          version:
+                          description:
                             type: string
                             minLength: 1
-                          vulnerabilities:
-                            type: array
-                            items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
-                                  minLength: 1
-                                namespaceName:
-                                  type: string
-                                  minLength: 1
-                                description:
-                                  type: string
-                                  minLength: 1
-                                link:
-                                  type: string
-                                  minLength: 1
-                                fixedby:
-                                  type: string
-                                  minLength: 1
-                                severity:
-                                  type: string
-                                  minLength: 1
-                                metadata:
-                                  type: string
-                                  minLength: 1
-                status:
-                  type: object
-                  properties:
-                    lastUpdate:
-                      type: string
-                      minLength: 1
-                    highestSeverity:
-                      type: string
-                      minLength: 1
-                    unknownCount:
-                      type: integer
-                      minimum: 0
-                    negligibleCount:
-                      type: integer
-                      minimum: 0
-                    lowCount:
-                      type: integer
-                      minimum: 0
-                    mediumCount:
-                      type: integer
-                      minimum: 0
-                    highCount:
-                      type: integer
-                      minimum: 0
-                    criticalCount:
-                      type: integer
-                      minimum: 0
-                    defcon1Count:
-                      type: integer
-                      minimum: 0
-                    fixableCount:
-                      type: integer
-                      minimum: 0
-                    affectedPods:
-                      type: object
-                      additionalProperties:
-                        type: array
-                        items:
-                          type: string
+                          link:
+                            type: string
+                            minLength: 1
+                          fixedby:
+                            type: string
+                            minLength: 1
+                          severity:
+                            type: string
+                            minLength: 1
+                          metadata:
+                            type: string
+                            minLength: 1
+          status:
+            type: object
+            properties:
+              lastUpdate:
+                type: string
+                minLength: 1
+              highestSeverity:
+                type: string
+                minLength: 1
+              unknownCount:
+                type: integer
+                minimum: 0
+              negligibleCount:
+                type: integer
+                minimum: 0
+              lowCount:
+                type: integer
+                minimum: 0
+              mediumCount:
+                type: integer
+                minimum: 0
+              highCount:
+                type: integer
+                minimum: 0
+              criticalCount:
+                type: integer
+                minimum: 0
+              defcon1Count:
+                type: integer
+                minimum: 0
+              fixableCount:
+                type: integer
+                minimum: 0
+              affectedPods:
+                type: object
+                additionalProperties:
+                  type: array
+                  items:
+                    type: string

--- a/dashdotdb/services/imagemanifestvuln.py
+++ b/dashdotdb/services/imagemanifestvuln.py
@@ -25,16 +25,12 @@ class ImageManifestVuln:
         self.namespace = namespace
 
     def insert(self, manifest):
-        for item in manifest['items']:
-            self._insert(item)
-
-    def _insert(self, item):
-        if 'kind' not in item:
+        if 'kind' not in manifest:
             self.log.error('skipping manifest: key "kind" not found')
             return
 
-        if item['kind'] != 'ImageManifestVuln':
-            self.log.info('skipping kind "%s"', item["kind"])
+        if manifest['kind'] != 'ImageManifestVuln':
+            self.log.info('skipping kind "%s"', manifest["kind"])
             return
 
         expire = datetime.now() - timedelta(minutes=60)
@@ -57,7 +53,7 @@ class ImageManifestVuln:
         db_cluster = db.session.query(Cluster) \
             .filter_by(name=cluster_name).first()
 
-        namespace_name = item['metadata']['namespace']
+        namespace_name = manifest['metadata']['namespace']
         db_namespace = db.session.query(Namespace) \
             .filter_by(name=namespace_name, cluster_id=db_cluster.id).first()
         if db_namespace is None:
@@ -68,8 +64,8 @@ class ImageManifestVuln:
         db_namespace = db.session.query(Namespace) \
             .filter_by(name=namespace_name, cluster_id=db_cluster.id).first()
 
-        image_name = item['spec']['image']
-        image_manifest = item['spec']['manifest']
+        image_name = manifest['spec']['image']
+        image_manifest = manifest['spec']['manifest']
         db_image = db.session.query(Image) \
             .filter_by(name=image_name, manifest=image_manifest).first()
         if db_image is None:
@@ -80,7 +76,7 @@ class ImageManifestVuln:
         db_image = db.session.query(Image) \
             .filter_by(name=image_name, manifest=image_manifest).first()
 
-        features = item['spec']['features']
+        features = manifest['spec']['features']
         for feature in features:
             feature_name = feature['name']
             feature_namespacename = feature['namespaceName']
@@ -145,7 +141,7 @@ class ImageManifestVuln:
                     self.log.info('vulnerability %s created ',
                                   vulnerability_name)
 
-        pods = item['status']['affectedPods'].keys()
+        pods = manifest['status']['affectedPods'].keys()
         for pod in pods:
             db_pod = db.session.query(Pod) \
                 .filter_by(name=pod,


### PR DESCRIPTION
The API was expecting a List of all imagemanifestvuln from a given
cluster, but that list is just way too big.

This patch changes the implementation so we expect each
imagemanifestvuln object individually. Now it's up to the client to loop
the list and post each imagemanifestvuln object.