### PR TITLE
update container source from dockerhub:centos/8 to rh-registry:ubi8/python-36

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM        centos:8
+FROM        registry.access.redhat.com/ubi8/python-36
 
 WORKDIR     /dashdotdb
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ WORKDIR     /dashdotdb
 
 COPY        . ./
 
-RUN         dnf -y install python36
 RUN         pip3 install .
 RUN         pip3 install gunicorn
 


### PR DESCRIPTION
"why isn't this deploy.... oh. right."
🤦  

ideally using ubi8 with the python-36 flavor, to see if that has minimally enough for dddb. if it ends up getting complex, there is also the generic "ubi8/ubi" image:

https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/building_running_and_managing_containers/index#using-appstream-runtime-images_adding-software-to-a-running-ubi-container
