### PR TITLE
token ttl for dddb-dvo in minutes: 5->50

### DIFF
--- a/dashdotdb/services/deploymentvalidation.py
+++ b/dashdotdb/services/deploymentvalidation.py
@@ -34,7 +34,7 @@ class DeploymentValidationData:
             self.log.error('skipping validation: key "value" not found')
             return
 
-        expire = datetime.now() - timedelta(minutes=5)
+        expire = datetime.now() - timedelta(minutes=50)
         db_token = db.session.query(Token) \
             .filter(Token.timestamp > expire).first()
         if db_token is None:


### PR DESCRIPTION
Very small single character fix. This changes the token ttl from 5 minutes to 50 minutes for dddb-dvo. This is the same tokenization that cso is using, but cso runs at every 6h instead of every 1h:
After this change:
cso - ttl:60m,  polls:6h
dvo - ttl:50m, polls:1h
