### PR TITLE
Add transactions

### DIFF
--- a/dashdotdb/controllers/deploymentvalidation.py
+++ b/dashdotdb/controllers/deploymentvalidation.py
@@ -1,12 +1,13 @@
 from dashdotdb.services.deploymentvalidation import DeploymentValidationData
+from dashdotdb.controllers.transactions import add_to_transaction
 
 
-def post(cluster, body):
-    dpv = DeploymentValidationData(cluster=cluster)
-    dpv.insert(validation=body)
+def post(transactionid, cluster, body):
+    dpv = DeploymentValidationData(cluster=cluster, validation=body)
+    add_to_transaction(transactionid, dpv)
     return 'ok'
 
 
 def search(cluster, namespace):
-    dpv = DeploymentValidationData(cluster, namespace)
+    dpv = DeploymentValidationData(cluster=cluster, namespace=namespace)
     return dpv.get_deploymentvalidations()

--- a/dashdotdb/controllers/imagemanifestvuln.py
+++ b/dashdotdb/controllers/imagemanifestvuln.py
@@ -1,12 +1,13 @@
 from dashdotdb.services.imagemanifestvuln import ImageManifestVuln
+from dashdotdb.controllers.transactions import add_to_transaction
 
 
-def post(cluster, body):
-    imv = ImageManifestVuln(cluster=cluster)
-    imv.insert(manifest=body)
+def post(transactionid, cluster, body):
+    imv = ImageManifestVuln(cluster=cluster, manifest=body)
+    add_to_transaction(transactionid, imv)
     return 'ok'
 
 
 def search(cluster, namespace):
-    imv = ImageManifestVuln(cluster, namespace)
+    imv = ImageManifestVuln(cluster=cluster, namespace=namespace)
     return imv.get_vulnerabilities()

--- a/dashdotdb/controllers/serviceslometrics.py
+++ b/dashdotdb/controllers/serviceslometrics.py
@@ -1,12 +1,14 @@
 from dashdotdb.services.serviceslometrics import ServiceSLOMetrics
+from dashdotdb.controllers.transactions import add_to_transaction
 
 
-def post(name, body):
-    slo = ServiceSLOMetrics(name=name)
-    slo.insert(slo=body)
+def post(transactionid, name, body):
+    slo = ServiceSLOMetrics(name=name, slo=body)
+    add_to_transaction(transactionid, slo)
     return 'ok'
 
 
 def search(cluster, namespace, sli_type, name):
-    slo = ServiceSLOMetrics(cluster, namespace, sli_type, name)
+    slo = ServiceSLOMetrics(
+        cluster=cluster, namespace=namespace, sli_type=sli_type, name=name)
     return slo.get_slometrics()

--- a/dashdotdb/controllers/transactions.py
+++ b/dashdotdb/controllers/transactions.py
@@ -1,0 +1,37 @@
+import threading
+
+from uuid import uuid4
+
+open_transactions = {}
+transaction_lock = threading.Lock()
+
+
+def add_to_transaction(transaction_id, obj):
+    with transaction_lock:
+        if transaction_id in open_transactions:
+            open_transactions[transaction_id].append(obj)
+        else:
+            # maybe return an error here instead?
+            open_transactions[transaction_id] = [obj]
+
+
+def post(transactionid):
+    # complete the transaction for the provided transaction id
+    if transactionid in open_transactions:
+        transactions = []
+        with transaction_lock:
+            transactions = open_transactions[transactionid]
+            del open_transactions[transactionid]
+
+        # write the data to db
+        for obj in transactions:
+            obj.insert()
+        return 'transaction committed'
+    return 'transaction id unknown', 404
+
+
+def get():
+    # generate a unique id
+    uuid = str(uuid4())
+    open_transactions[uuid] = []
+    return uuid

--- a/dashdotdb/schemas/swagger.yaml
+++ b/dashdotdb/schemas/swagger.yaml
@@ -11,6 +11,37 @@ info:
 servers:
 - url: /api/v1
 paths:
+  /starttransaction:
+    get:
+      operationId: dashdotdb.controllers.transactions.get
+      summary: Start a transaction
+      responses:
+        "200":
+          description: transaction started
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  transactionid:
+                    type: string
+                    description: The unique ID for the transaction
+
+  /endtransaction:
+    post:
+      operationId: dashdotdb.controllers.transactions.post
+      summary: End a transaction
+      parameters:
+      - name: transactionid
+        in: query
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: transaction accepted
+        "404":
+          description: transaction not found
   /metrics:
     get:
       summary: Lists Image Manifests Vulnerabilities
@@ -52,6 +83,11 @@ paths:
     post:
       summary: Add a new Vulnerability Notification
       parameters:
+        - name: transactionid
+          in: query
+          required: true
+          schema:
+            type: string
         - name: cluster
           in: path
           required: true
@@ -94,6 +130,11 @@ paths:
     post:
       summary: Add a new Deployment Validation
       parameters:
+        - name: transactionid
+          in: query
+          required: true
+          schema:
+            type: string
         - name: cluster
           in: path
           required: true
@@ -147,6 +188,11 @@ paths:
       parameters:
         - name: name
           in: path
+          required: true
+          schema:
+            type: string
+        - name: transactionid
+          in: query
           required: true
           schema:
             type: string

--- a/dashdotdb/services/deploymentvalidation.py
+++ b/dashdotdb/services/deploymentvalidation.py
@@ -15,15 +15,17 @@ from dashdotdb.models.dashdotdb import ObjectKind
 
 
 class DeploymentValidationData:
-    def __init__(self, cluster=None, namespace=None):
+    def __init__(self, cluster=None, namespace=None, validation=None):
         self.log = logging.getLogger()
 
         self.cluster = cluster
         self.namespace = namespace
+        self.validation = validation
 
-    def insert(self, validation):
-        for item in validation['data']['result']:
-            self._insert(item)
+    def insert(self):
+        if self.validation:
+            for item in self.validation['data']['result']:
+                self._insert(item)
 
     def _insert(self, item):
         if 'metric' not in item:


### PR DESCRIPTION
This PR adds crude transactions.  The intention is to help shelter the db against continuous writes and prepare to have a cache of the latest completed set of data for querying.  With this implementation, 2 new endpoints are added for starting and ending a transaction.  Clients have to provide a transaction id when updating data in dashdotdb, and nothing will be written to the db until the transaction is ended by the client.

What is not implemented at the moment is any cleaning of the transactions.  If a client crashes or doesn't complete the transaction, it will hang around in memory.  The eventual goal is to throw the transaction data into a cache (like redis) and then only write to the db on transaction completion.  That same data would then be written into a cache (in db or redis) and that latest version would be used for queries.

This is part of: https://issues.redhat.com/browse/APPSRE-2910