### PR TITLE
specify that value and target are not nullable

### DIFF
--- a/dashdotdb/models/dashdotdb.py
+++ b/dashdotdb/models/dashdotdb.py
@@ -198,8 +198,8 @@ class ServiceSLO(db.Model):
 
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(64), unique=False, index=True)
-    value = db.Column(db.Float, unique=False)
-    target = db.Column(db.Float, unique=False)
+    value = db.Column(db.Float, unique=False, nullable=False)
+    target = db.Column(db.Float, unique=False, nullable=False)
     # no index, slitype is a very small table
     slitype_id = db.Column(db.Integer, db.ForeignKey('slitype.id'))
     token_id = db.Column(db.Integer, db.ForeignKey('token.id'), index=True)


### PR DESCRIPTION
The database migration to change `value` and `target` to type float was
created manually, and now every time we run `flask db migrate` it tries
to create a new migration to change those values to nullable.

This PR adds `nullable=False` to the data types so it matches the
current state of the database, therefore this avoids migrations.