### PR TITLE
remove reference to builtin prometheus endpoint from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,21 +113,6 @@ $ curl "localhost:8080/api/v1/imagemanifestvuln?cluster=app-sre-prod-01&namespac
 ...
 ```
 
-Prometheus metrics endpoint:
-
-```
-$ curl "localhost:8080/api/v1/metrics"
-...
-# HELP imagemanifestvuln_total Vulnerabilities total per severity
-# TYPE imagemanifestvuln_total counter
-imagemanifestvuln_total{cluster="app-sre-prod-01",namespace="cso",severity="Medium"} 86.0
-imagemanifestvuln_total{cluster="app-sre-prod-01",namespace="cso",severity="High"} 43.0
-imagemanifestvuln_total{cluster="app-sre-prod-01",namespace="cso",severity="Low"} 20.0
-imagemanifestvuln_total{cluster="app-sre-prod-01",namespace="cso",severity="Unknown"} 5.0
-imagemanifestvuln_total{cluster="app-sre-prod-01",namespace="cso",severity="Critical"} 4.0
-...
-```
-
 # Changing the Database Model
 
 The current Entity Relationship Diagram looks like this:


### PR DESCRIPTION
As far as I can tell, this app does not expose any Prometheus metrics endpoints. I am guessing this was either a now-removed feature, or perhaps this was simply added to the readme on accident.