### PR TITLE
DVO Check Failure Remediations

### DIFF
--- a/dashdotdb/__init__.py
+++ b/dashdotdb/__init__.py
@@ -24,18 +24,18 @@ if DATABASE_URL is None:
                     f'{DATABASE_NAME}')
 
 
-def liveness():
-    pass
-
-
-def readiness():
-    try:
-        db.engine.execute('SELECT 1')
-    except Exception:
-        raise HealthError("Can't connect to the database")
-
-
 class DashDotDb(App):
+    @staticmethod
+    def liveness():
+        pass
+
+    @staticmethod
+    def readiness():
+        try:
+            db.engine.execute('SELECT 1')
+        except Exception:
+            raise HealthError("Can't connect to the database")
+
     def create_app(self):
         # pylint: disable=redefined-outer-name
         app = Flask(self.import_name, **self.server_args)

--- a/dashdotdb/__init__.py
+++ b/dashdotdb/__init__.py
@@ -23,6 +23,7 @@ if DATABASE_URL is None:
                     f'{DATABASE_PORT}/'
                     f'{DATABASE_NAME}')
 
+
 class DashDotDb(App):
     def liveness(self):
         pass
@@ -32,7 +33,7 @@ class DashDotDb(App):
             db.engine.execute('SELECT 1')
         except Exception:
             raise HealthError("Can't connect to the database")
-    
+
     def create_app(self):
         # pylint: disable=redefined-outer-name
         app = Flask(self.import_name, **self.server_args)

--- a/dashdotdb/__init__.py
+++ b/dashdotdb/__init__.py
@@ -2,7 +2,7 @@ import os
 
 from flask import Flask
 from flask_migrate import Migrate
-from flask_healthz import healthz, HealthError
+from flask_healthz import healthz, HealthError # type: ignore  # noqa: F401
 from connexion import App
 from connexion.resolver import RestyResolver
 

--- a/dashdotdb/__init__.py
+++ b/dashdotdb/__init__.py
@@ -2,7 +2,7 @@ import os
 
 from flask import Flask
 from flask_migrate import Migrate
-from flask_healthz import healthz, HealthError # type: ignore  # noqa: F401
+from flask_healthz import healthz, HealthError  # type: ignore  # noqa: F401
 from connexion import App
 from connexion.resolver import RestyResolver
 

--- a/dashdotdb/__init__.py
+++ b/dashdotdb/__init__.py
@@ -46,8 +46,8 @@ class DashDotDb(App):
         # pylint: disable=unused-variable
         migrate = Migrate(app, db)  # type: ignore  # noqa: F841
         app.config['HEALTHZ'] = {
-            "live": liveness,
-            "ready": readiness,
+            "live": self.liveness,
+            "ready": self.readiness,
         }
         return app
 

--- a/dashdotdb/__init__.py
+++ b/dashdotdb/__init__.py
@@ -2,6 +2,7 @@ import os
 
 from flask import Flask
 from flask_migrate import Migrate
+from flask_healthz import healthz, HealthError
 from connexion import App
 from connexion.resolver import RestyResolver
 
@@ -22,16 +23,29 @@ if DATABASE_URL is None:
                     f'{DATABASE_PORT}/'
                     f'{DATABASE_NAME}')
 
-
 class DashDotDb(App):
+    def liveness(self):
+        pass
+
+    def readiness(self, db):
+        try:
+            pass # Have to figure this out
+        except Exception:
+            raise HealthError("Can't connect to the database")
+    
     def create_app(self):
         # pylint: disable=redefined-outer-name
         app = Flask(self.import_name, **self.server_args)
+        app.register_blueprint(healthz, url_prefix="/api/healthz")
         app.config['SQLALCHEMY_DATABASE_URI'] = DATABASE_URL
         app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
         db.init_app(app)
         # pylint: disable=unused-variable
         migrate = Migrate(app, db)  # type: ignore  # noqa: F841
+        app.config['HEALTHZ'] = {
+            "live": self.liveness,
+            "ready": self.readiness,
+        }
         return app
 
 

--- a/dashdotdb/__init__.py
+++ b/dashdotdb/__init__.py
@@ -27,9 +27,9 @@ class DashDotDb(App):
     def liveness(self):
         pass
 
-    def readiness(self, db):
+    def readiness(self):
         try:
-            pass # Have to figure this out
+            db.engine.execute('SELECT 1')
         except Exception:
             raise HealthError("Can't connect to the database")
     

--- a/dashdotdb/__init__.py
+++ b/dashdotdb/__init__.py
@@ -24,16 +24,18 @@ if DATABASE_URL is None:
                     f'{DATABASE_NAME}')
 
 
+def liveness():
+    pass
+
+
+def readiness():
+    try:
+        db.engine.execute('SELECT 1')
+    except Exception:
+        raise HealthError("Can't connect to the database")
+
+
 class DashDotDb(App):
-    def liveness(self):
-        pass
-
-    def readiness(self):
-        try:
-            db.engine.execute('SELECT 1')
-        except Exception:
-            raise HealthError("Can't connect to the database")
-
     def create_app(self):
         # pylint: disable=redefined-outer-name
         app = Flask(self.import_name, **self.server_args)
@@ -44,8 +46,8 @@ class DashDotDb(App):
         # pylint: disable=unused-variable
         migrate = Migrate(app, db)  # type: ignore  # noqa: F841
         app.config['HEALTHZ'] = {
-            "live": self.liveness,
-            "ready": self.readiness,
+            "live": liveness,
+            "ready": readiness,
         }
         return app
 

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -5,6 +5,10 @@ metadata:
   name: dashdotdb
 objects:
 - apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: dashdotdb
+- apiVersion: v1
   kind: ConfigMap
   metadata:
     labels:
@@ -79,6 +83,17 @@ objects:
         labels:
           app: dashdotdb
       spec:
+        serviceAccountName: dashdotdb
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - dashdotdb
+              topologyKey: "kubernetes.io/hostname"
         containers:
         - image: ${IMAGE_GATE}:${IMAGE_GATE_TAG}
           imagePullPolicy: Always
@@ -153,6 +168,18 @@ objects:
           ports:
           - name: dashdotdb
             containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /api/healthz/live
+              port: 8080
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /api/healthz/ready
+              port: 8080
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
         volumes:
         - configMap:
             defaultMode: 420

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(name='dashdotdb',
       install_requires=[
             'connexion[swagger-ui] ~= 2.7',
             'Flask ~= 1.1',
+            'flask-healthz ~= 0.0.3',
             'Flask-Migrate ~= 2.5',
             'Flask-SQLAlchemy ~= 2.4',
             'psycopg2-binary ~= 2.8',


### PR DESCRIPTION
This MR fixes four issues uncovered by DVO: 

* default-service-account
* no-anti-affinity
* no-liveness-probe
* no-readness-probe

Default service account and no anti affinity are handled in the OpenShift template.

Liveness + Readiness probes were achieved with `flask-healthz`, written by a fellow Red Hatter. Small changes were made to the init script for the Flask app.

I still need to figure out a better way to determine readiness. Somehow, I think a db connection / ping check would be appropriate. However, I haven't found a simple way to do this (SQLAlchemy docs are quite verbose and need more time than I have on a Friday afternoon).

@bkez322 I'll fix the lint errors before a full review. However, any ideas you have on SQLA <> Flask and setting up a good readiness endpoint would be welcome. 