### PR TITLE
fix markupsafe import error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(name='dashdotdb',
             'prometheus-client ~= 0.8',
             'gunicorn ~= 20.0',
             'openapi-schema-validator ~= 0.1.5',
-            'jsonschema ~= 3.0'
+            'jsonschema ~= 3.0',
+            'markupsafe == 2.0.1'
       ],
       )


### PR DESCRIPTION
fix `ImportError: cannot import name 'soft_unicode' from 'markupsafe'` 

https://markupsafe.palletsprojects.com/en/2.1.x/changes/#version-2-1-0

Signed-off-by: Feng Huang <fehuang@redhat.com>