### PR TITLE
APPSRE-4572: Add REPLICAS parameter to the deployment template

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -77,7 +77,7 @@ objects:
       app: dashdotdb
     name: dashdotdb
   spec:
-    replicas: 3
+    replicas: ${{REPLICAS}}
     strategy:
       type: RollingUpdate
       rollingUpdate:
@@ -263,3 +263,5 @@ parameters:
   value: quay.io/app-sre/nginx-gate
 - name: IMAGE_GATE_TAG
   value: latest
+- name: REPLICAS
+  value: "3"


### PR DESCRIPTION
Add the **`REPLICAS`** parameter to the deployment template, thus allowing for the **dashdotdb** service to be scaled up or down as needed (e.g., during a maintenance, etc.) through the corresponding SaaS configuration file.

Signed-off-by: Krzysztof Wilczyński <kwilczynski@redhat.com>