### PR TITLE
APPSRE-6759 increase col size

### DIFF
--- a/dashdotdb/models/dashdotdb.py
+++ b/dashdotdb/models/dashdotdb.py
@@ -86,7 +86,7 @@ class Image(db.Model):
     __tablename__ = 'image'
 
     id = db.Column(db.Integer, primary_key=True)
-    name = db.Column(db.String(64), unique=False)
+    name = db.Column(db.String(128), unique=False)
     manifest = db.Column(db.String(1000), unique=False)
     features = db.relationship('Feature', secondary='imagefeature')
     pods = db.relationship('Pod', backref='image')

--- a/migrations/versions/9d64fd56c7e4_.py
+++ b/migrations/versions/9d64fd56c7e4_.py
@@ -1,0 +1,26 @@
+"""empty message
+
+Revision ID: 9d64fd56c7e4
+Revises: 963bd51e139c
+Create Date: 2023-01-11 14:24:27.047343
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '9d64fd56c7e4'
+down_revision = '963bd51e139c'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Alembic does not alter the varchar(64) change - need to do this manually here
+    op.execute('ALTER TABLE image ALTER COLUMN name TYPE varchar(128);')
+
+
+def downgrade():
+    # Alembic does not alter the varchar(64) change - need to do this manually here
+    op.execute('ALTER TABLE image ALTER COLUMN name TYPE varchar(64);')


### PR DESCRIPTION
Example that requires more space

```
sqlalchemy.exc.DataError: (psycopg2.errors.StringDataRightTruncation) value too long for type character varying(64)
[SQL: INSERT INTO image (name, manifest) VALUES (%(name)s, %(manifest)s) RETURNING image.id]
[parameters: {'name': 'quay.io/openshift-pipeline/openshift-pipelines-pipelines-cli-tkn-rhel8@sha256', 'manifest': 'sha256:a3d913d074a5ac035f437525d17be93225099056344cce9310ff188c1d423b1e'}]
```