### PR TITLE
Run test data queries during PR check

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,23 +1,26 @@
 ---
-version: "3.9"
 services:
   db:
-    container_name: dashdot-postgres
-    image: postgres
+    image: registry.redhat.io/rhel9/postgresql-15
     environment:
-      - POSTGRES_PASSWORD=postgres
-    ports:
-      - 5432:5432
+      - POSTGRESQL_PASSWORD=postgres
+      - POSTGRESQL_USER=dashdotdb
+      - POSTGRESQL_DATABASE=dashdotdb
+    networks:
+    - dashdotdb
 
   app:
-    stdin_open: true
-    tty: true
-    links:
-      - db
+    container_name: ${WEB_CONTAINER_NAME}
+    networks:
+    - dashdotdb
     build:
       context: .
       dockerfile: ./Dockerfile
     environment:
-      - DASHDOTDB_DATABASE_URL=postgresql://postgres:postgres@db:5432/postgres
+      - DASHDOTDB_DATABASE_URL=postgresql://dashdotdb:postgres@db:5432/dashdotdb
     ports:
-      - 8080:8080
+      - 8080
+    restart: always
+
+networks:
+  dashdotdb:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,9 +8,21 @@ services:
       - POSTGRESQL_DATABASE=dashdotdb
     networks:
     - dashdotdb
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U dashdotdb -d dashdotdb"]
+      interval: 10s
+      retries: 5
+      start_period: 30s
+      timeout: 10s
 
   app:
+    stdin_open: true
+    tty: true
     container_name: ${WEB_CONTAINER_NAME}
+    depends_on:
+      db:
+        condition: service_healthy
+        restart: true
     networks:
     - dashdotdb
     build:

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -1,5 +1,41 @@
 #!/bin/bash
 
-set -exvo pipefail
+set -xvo pipefail
+
+# $1: api_type
+# $2: web app port
+test_data() {
+    TOKEN=$(curl --silent http://localhost:$2/api/v1/token?scope=$1 | sed 's/"//g')
+    POST_RES=$(curl --silent -X POST --header "Content-Type: application/json" --header "X-Auth: $TOKEN" --data @examples/$1.json http://localhost:$2/api/v1/$1/app-sre-prod-01)
+    if [[ ! $POST_RES =~ "ok" ]]; then
+        echo "test of $1 api failed, returning '$POST_RES' when 'ok' was expected"
+        RETURN=1
+    fi
+    curl --silent --request DELETE "http://localhost:$2/api/v1/token/$TOKEN?scope=$1"
+}
 
 make ci
+RETURN=$?
+
+IP=$(hostname -I | tr -d '[:blank:]')
+
+DB_CONTAINER=dashdotdb-pg
+APP_CONTAINER=dashdotdb-app
+
+podman run --rm -d -e POSTGRESQL_PASSWORD=postgres -e POSTGRESQL_USER=dashdotdb -e POSTGRESQL_DATABASE=dashdotdb --health-cmd "pg_isready -U dashdotdb -d dashdotdb" --name dashdotdb-pg -p 5432 registry.redhat.io/rhel9/postgresql-15
+podman wait --condition=healthy $DB_CONTAINER
+PG_PORT=$(podman port "${DB_CONTAINER}" | awk -F: '{print $2}')
+
+podman run --rm -d -e DASHDOTDB_DATABASE_URL=postgresql://dashdotdb:postgres@$IP:$PG_PORT/dashdotdb -p 8080 --health-cmd "curl -f http://localhost:8080/api/healthz/ready" --name $APP_CONTAINER app-sre-dashdotdb:do-not-use
+podman wait --condition=healthy $APP_CONTAINER
+
+
+WEB_PORT=$(podman port "${APP_CONTAINER}" | awk -F: '{print $2}')
+
+test_data imagemanifestvuln "$WEB_PORT"
+test_data serviceslometrics "$WEB_PORT"
+test_data deploymentvalidation "$WEB_PORT"
+
+podman stop $APP_CONTAINER $DB_CONTAINER
+
+exit $RETURN

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
-
 set -xvo pipefail
+
+# This script performs a build of the Dockerfile.ci image which performs type checking and linting
+# This is followed by an integration test of the application using a Postgres DB that is spun up with
+# Podman. The reason I'm using these raw podman commands rather than podman-compose is due to limitations
+# in Podman compose, specifically that the `depends_on` healthcheck feature isn't supported
+# (see: https://github.com/containers/podman-compose/issues/866)
+# once the DB & web-app are spun up, several queries are run to validate the DB functionality
+# and finally everything is torn down in the end
 
 # $1: api_type
 # $2: web app port


### PR DESCRIPTION
[APPSRE-10993](https://issues.redhat.com/browse/APPSRE-10993)

Improves the testing process for dashdotdb by using `podman-compose` to run the test data scripts during PR check.

Previously, these scripts were run by doing a `docker compose up` & `make test-data` on the local user's laptop. This update moves that functionality to be executed during PR check so we have more confidence with updates. In the process, I also discovered that `podman-compose` was missing some functionality that `docker-compose` has around setting service dependencies. In this case, I wasn't able to start up the postgres DB first and then launch the app afterwards so I resorted to raw podman commands for that in the PR check script.
