### PR TITLE
SDCICD-1777 Add GitOps deployment manifests

### DIFF
--- a/deploy/base/configmap-nginx-dynamic.yaml
+++ b/deploy/base/configmap-nginx-dynamic.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: dashdotdb
+  name: nginx-dynamic-conf
+data:
+  nginx.conf: |
+    daemon off;
+    worker_processes 1;
+    error_log /dev/stderr;
+    pid /tmp/nginx.pid;
+
+    events {
+        worker_connections 1024;
+    }
+
+    http {
+      log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                        '$status $body_bytes_sent "$http_referer" '
+                        '"$http_user_agent" "$http_x_forwarded_for"';
+      upstream app {
+        server ${FORWARD_HOST};
+        keepalive 64;
+      }
+
+      server {
+        listen *:${LISTEN_PORT};
+        server_name _;
+        access_log  /dev/stdout  main;
+        error_log /dev/stderr;
+        auth_basic "Restricted Area";
+        auth_basic_user_file /tmp/auth.htpasswd;
+
+        include /etc/nginx/conf.d/*.conf;
+
+        location / {
+          proxy_pass http://app;
+          proxy_connect_timeout 300;
+          proxy_send_timeout 300;
+          proxy_read_timeout 300;
+          send_timeout 300;
+        }
+
+        location /healthz {
+          access_log off;
+          auth_basic "off";
+          allow all;
+          default_type text/plain;
+          return 200 "healthy\n";
+        }
+      }
+    }

--- a/deploy/base/configmap-nginx-postsize.yaml
+++ b/deploy/base/configmap-nginx-postsize.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: dashdotdb
+  name: nginx-postsize
+data:
+  nginx-postsize.conf: |
+    client_max_body_size 20m;

--- a/deploy/base/deployment.yaml
+++ b/deploy/base/deployment.yaml
@@ -1,0 +1,152 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    ignore-check.kube-linter.io/unset-cpu-requirements: no cpu limits
+  labels:
+    app: dashdotdb
+  name: dashdotdb
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: dashdotdb
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: dashdotdb
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - dashdotdb
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      containers:
+      - env:
+        - name: FORWARD_HOST
+          value: 0.0.0.0:8080
+        - name: LISTEN_PORT
+          value: "8000"
+        - name: BASIC_AUTH_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: auth-proxy
+        - name: BASIC_AUTH_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: auth-proxy
+        image: quay.io/app-sre/nginx-gate:latest
+        imagePullPolicy: Always
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: auth-proxy
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: auth-proxy
+        ports:
+        - containerPort: 8000
+          name: auth-proxy
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: auth-proxy
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 300Mi
+          requests:
+            cpu: 10m
+            memory: 200Mi
+        volumeMounts:
+        - mountPath: /etc/nginx/conf.d
+          name: nginx-postsize
+        - mountPath: /nginx.conf
+          name: nginx-dynamic-conf
+          subPath: nginx.conf
+      - env:
+        - name: DATABASE_HOST
+          valueFrom:
+            secretKeyRef:
+              key: db.host
+              name: dashdotdb-rds
+        - name: DATABASE_PORT
+          valueFrom:
+            secretKeyRef:
+              key: db.port
+              name: dashdotdb-rds
+        - name: DATABASE_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: db.user
+              name: dashdotdb-rds
+        - name: DATABASE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: db.password
+              name: dashdotdb-rds
+        - name: DATABASE_NAME
+          valueFrom:
+            secretKeyRef:
+              key: db.name
+              name: dashdotdb-rds
+        image: quay.io/app-sre/dashdotdb:latest
+        imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            path: /api/healthz/live
+            port: 8080
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+        name: dashdotdb
+        ports:
+        - containerPort: 8080
+          name: dashdotdb
+        readinessProbe:
+          httpGet:
+            path: /api/healthz/ready
+            port: 8080
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 300Mi
+          requests:
+            cpu: 10m
+            memory: 200Mi
+      serviceAccountName: dashdotdb
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: nginx-postsize
+        name: nginx-postsize
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: nginx.conf
+            path: nginx.conf
+          name: nginx-dynamic-conf
+        name: nginx-dynamic-conf

--- a/deploy/base/kustomization.yaml
+++ b/deploy/base/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- serviceaccount.yaml
+- configmap-nginx-postsize.yaml
+- configmap-nginx-dynamic.yaml
+- deployment.yaml
+- service-dashdotdb.yaml
+- service-internal.yaml
+
+labels:
+- pairs:
+    app.kubernetes.io/name: dashdotdb
+    app.kubernetes.io/part-of: app-sre

--- a/deploy/base/service-dashdotdb.yaml
+++ b/deploy/base/service-dashdotdb.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: dashdotdb
+  name: dashdotdb
+spec:
+  ports:
+  - name: auth-proxy
+    port: 80
+    protocol: TCP
+    targetPort: 8000
+  selector:
+    app: dashdotdb

--- a/deploy/base/service-internal.yaml
+++ b/deploy/base/service-internal.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: dashdotdb
+  name: internal
+spec:
+  ports:
+  - name: dashdotdb
+    port: 80
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: dashdotdb

--- a/deploy/base/serviceaccount.yaml
+++ b/deploy/base/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dashdotdb


### PR DESCRIPTION
Add base Kustomize manifests for GitOps deployment:

- Deployment with dashdotdb and nginx-gate containers
- ServiceAccount for pod identity
- Services for external and internal access
- ConfigMaps for nginx configuration:
  - Dynamic routing configuration
  - Post size limits

These manifests are referenced by app-sre-cd GitOps overlays for automated deployment to staging and production environments.